### PR TITLE
Added integration test for /api/actors endpoint.

### DIFF
--- a/src/app/tests/actor.integration.ts
+++ b/src/app/tests/actor.integration.ts
@@ -8,8 +8,19 @@ chai.use(chaiHttp);
 
 describe("Testing Actor Controller Methods", () => {
 
+  it("Testing /api/actors", async () => {
+    const queryId = "nm0000323";
+    return chai.request(server)
+    .get(`/api/actors`)
+    .then((res) => {
+      chai.expect(res).to.have.status(200);
+      const id = res.body[0].actorId;
+      chai.assert.equal(queryId, id);
+    });
+  });
+
   it("Testing /api/actors/:id", async () => {
-    const queryId = "nm0000345";
+    const queryId = "nm0000323";
     return chai.request(server)
     .get(`/api/actors/${queryId}`)
     .then((res) => {

--- a/src/app/tests/actor.integration.ts
+++ b/src/app/tests/actor.integration.ts
@@ -2,7 +2,7 @@ import * as chai from "chai";
 import chaiHttp = require("chai-http");
 import "mocha";
 
-const server = "https://seusherhelium.azurewebsites.net/";
+const server = "https://heliumint.azurewebsites.net/";
 
 chai.use(chaiHttp);
 


### PR DESCRIPTION
To test:

1. Clone repository
2. `docker build --target=integration -t helium:canary .`

Output should show that integration tests ran, as follows:

```
> helium@1.0.0 test-integration /app
> mocha --reporter spec --compilers ts:ts-node/register '**/*.integration.ts'

  Example test
    ✓ should output a test result

  Testing Actor Controller Methods
    ✓ Testing /api/actors (886ms)
    ✓ Testing /api/actors/:id (285ms)

  3 passing (1s)
```