### PR TITLE
Changed property validation messages for textSearch

### DIFF
--- a/src/app/models/actor.ts
+++ b/src/app/models/actor.ts
@@ -6,6 +6,7 @@ import {
     NotEquals,
     validate,
     ValidateIf,
+    ValidationArguments,
     ValidationError,
 } from "class-validator";
 import { IsEqualToProperty } from "../../utilities/validationUtilities";
@@ -25,7 +26,13 @@ export class Actor implements IValidatable {
     @ValidateIf((x) => x.name !== undefined)
     @IsEqualToProperty("name", (x) => (x as string).toLowerCase(),
         {
-            message: "textSearch must equal the lowercase version of 'name'",
+            message: (args: ValidationArguments) => {
+                if ((args.object as Actor).name !== undefined) {
+                    return `textSearch must be equal to ${(args.object as Actor).name.toLowerCase()}`;
+                } else {
+                    return `textSearch must equal the lowercased version of the object's ${args.targetName} property`;
+                }
+            },
         })
     @IsLowercase()
     public textSearch: string;

--- a/src/app/models/movie.ts
+++ b/src/app/models/movie.ts
@@ -6,6 +6,7 @@ import {
     NotEquals,
     validate,
     ValidateIf,
+    ValidationArguments,
     ValidationError,
 } from "class-validator";
 import { IsEqualToProperty } from "../../utilities/validationUtilities";
@@ -25,7 +26,13 @@ export class Movie implements IValidatable {
     @ValidateIf((x) => x.title !== undefined)
     @IsEqualToProperty("title", (x) => (x as string).toLowerCase(),
         {
-            message: "textSearch must equal the lowercase version of 'title'",
+            message: (args: ValidationArguments) => {
+                if ((args.object as Movie).title !== undefined) {
+                    return `textSearch must be equal to ${(args.object as Movie).title.toLowerCase()}`;
+                } else {
+                    return `textSearch must equal the lowercased version of the object's ${args.targetName} property`;
+                }
+            },
         })
     @IsLowercase()
     public textSearch: string;


### PR DESCRIPTION
Rewrote the validation messages for textSearch to better communicate the error to end users.