### PR TITLE
Allow for using App Service-specific MSIs for Key Vault Access

### DIFF
--- a/src/secrets/keyvaultprovider.ts
+++ b/src/secrets/keyvaultprovider.ts
@@ -49,7 +49,7 @@ export class KeyVaultProvider {
 
         // TODO (seusher): Validate MSI works with App Service containers
         const creds = this.clientId === undefined || this.clientId === "" ?
-                    await msrestazure.loginWithMSI() :
+                    await msrestazure.loginWithAppServiceMSI({resource: "https://vault.azure.net"}) :
                     await msrestazure.loginWithServicePrincipalSecret(this.clientId, this.clientSecret, this.tenantId);
 
         this.client = new keyvault.KeyVaultClient(creds);

--- a/src/server.ts
+++ b/src/server.ts
@@ -65,16 +65,13 @@ export async function getConfigValues(): Promise<{cosmosDbKey: string, cosmosDbU
     let configFallback: boolean;
 
     // try to get KeyVault connection details from env
+    // Whether or not we have clientId and clientSecret, we want to use KeyVault
     const clientId = process.env.CLIENT_ID;
-    if (!clientId) {
-        console.log("No CLIENT_ID env var set");
-        configFallback = true;
-    }
-
     const clientSecret = process.env.CLIENT_SECRET;
-    if (!clientSecret) {
-        console.log("No CLIENT_SECRET env var set");
-        configFallback = true;
+
+    if (clientId && !clientSecret) {
+        console.log("CLIENT_ID env var set, but not CLIENT_SECRET");
+        process.exit(1);
     }
 
     const tenantId = process.env.TENANT_ID;

--- a/src/server.ts
+++ b/src/server.ts
@@ -91,8 +91,12 @@ export async function getConfigValues(): Promise<{cosmosDbKey: string, cosmosDbU
         const keyVaultUrl = process.env.KEY_VAULT_URL;
         const keyvault = new KeyVaultProvider(keyVaultUrl, clientId, clientSecret, tenantId);
 
-        cosmosDbKey = await keyvault.getSecret("cosmosDBkey");
-        insightsKey = await keyvault.getSecret("AppInsightsInstrumentationKey");
+        try {
+            cosmosDbKey = await keyvault.getSecret("cosmosDBkey");
+            insightsKey = await keyvault.getSecret("AppInsightsInstrumentationKey");
+        } catch {
+            console.log("Failed to get secrets from KeyVault. Falling back to env vars for secrets");
+        }
 
     } else {
         console.log("Unable to use KeyVault, falling back to env vars for secrets");


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the KeyVault auth call from `loginWithMSI` to an App Service specific call `loginWithAppServiceMSI`. This is needed to allow KeyVault to fallback to the MSI on the App Service instance if we don't explicitly set CLIENT_ID.

With this change we will always attempt to get secrets from KeyVault if TENANT_ID is set, and then override them with what we specify in environment variables.

The Cobalt team has chosen to encourage all Cobalt users to directly access KeyVault in their code and not use secret injection provided by App Service.

**Special notes for your reviewer**:

You can only test this on a real App Service instance that has an identity assigned. Just don't specify a `CLIENT_ID` property in the `Configuration` tab, and the service will fall back to using the MSI. 
