### PR TITLE
change variable name format permissions in linter

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -10,6 +10,6 @@
       "ordered-imports": false,
       "quotemark": [true, "double"],
       "no-console": false,
-      "variable-name": [true, "allow-leading-underscore"]
+      "variable-name": [true, "allow-leading-underscore", "allow-pascal-case"]
     }
   }


### PR DESCRIPTION
There is one variable in the codebase that starts with a capital letter. This change is needed for that.
